### PR TITLE
Fix settings dialog layout and adjust defaults

### DIFF
--- a/AppConfig.cs
+++ b/AppConfig.cs
@@ -13,7 +13,7 @@ namespace BirthdayExtractor
         public int MinAge { get; set; } = 3;
         public int MaxAge { get; set; } = 14;
 
-        public bool DefaultWriteCsv { get; set; } = true;
+        public bool DefaultWriteCsv { get; set; } = false;
         public bool DefaultWriteXlsx { get; set; } = true;
 
         // New property
@@ -29,7 +29,7 @@ namespace BirthdayExtractor
             => s1 <= e2 && s2 <= e1;
     
         // New: enable libphonenumber for all numbers
-        public bool UseLibPhoneNumber { get; set; } = false;
+        public bool UseLibPhoneNumber { get; set; } = true;
 
         // Default country for parsing ambiguous numbers (e.g. "050...")
         public string DefaultRegion { get; set; } = "AE";

--- a/Processing.cs
+++ b/Processing.cs
@@ -18,14 +18,14 @@ namespace BirthdayExtractor
         public DateTime End { get; set; }
         public int MinAge { get; set; } = 3;
         public int MaxAge { get; set; } = 14;
-        public bool WriteCsv { get; set; } = true;
+        public bool WriteCsv { get; set; } = false;
         public bool WriteXlsx { get; set; } = true;
         public string OutDir { get; set; } = string.Empty;
 
         public IProgress<int>? Progress { get; set; }
         public Action<string>? Log { get; set; }
         public CancellationToken Cancellation { get; set; }
-        public bool UseLibPhoneNumber { get; set; } = false;
+        public bool UseLibPhoneNumber { get; set; } = true;
         public string DefaultRegion { get; set; } = "AE";
     }
 

--- a/SettingsForm.cs
+++ b/SettingsForm.cs
@@ -30,14 +30,21 @@ namespace BirthdayExtractor
 
             var y = 20;
             Controls.Add(new Label { Left = 20, Top = y, Width = 220, Text = "Default start offset (days from today):" });
-            numOffset = new NumericUpDown { Left = 260, Top = y - 2, Width = 200, Minimum = 0, Maximum = 365, Value = _cfg.DefaultStartOffsetDays }; y += 30;
+            numOffset = new NumericUpDown { Left = 260, Top = y - 2, Width = 200, Minimum = 0, Maximum = 365, Value = _cfg.DefaultStartOffsetDays };
+            Controls.Add(numOffset);
+            y += 30;
 
             Controls.Add(new Label { Left = 20, Top = y, Width = 220, Text = "Default window length (days):" });
-            numWindow = new NumericUpDown { Left = 260, Top = y - 2, Width = 200, Minimum = 1, Maximum = 60, Value = _cfg.DefaultWindowDays }; y += 30;
+            numWindow = new NumericUpDown { Left = 260, Top = y - 2, Width = 200, Minimum = 1, Maximum = 60, Value = _cfg.DefaultWindowDays };
+            Controls.Add(numWindow);
+            y += 30;
 
             Controls.Add(new Label { Left = 20, Top = y, Width = 220, Text = "Age range (min / max):" });
             numMinAge = new NumericUpDown { Left = 260, Top = y - 2, Width = 90, Minimum = 0, Maximum = 120, Value = _cfg.MinAge };
-            numMaxAge = new NumericUpDown { Left = 370, Top = y - 2, Width = 90, Minimum = 0, Maximum = 120, Value = _cfg.MaxAge }; y += 30;
+            numMaxAge = new NumericUpDown { Left = 370, Top = y - 2, Width = 90, Minimum = 0, Maximum = 120, Value = _cfg.MaxAge };
+            Controls.Add(numMinAge);
+            Controls.Add(numMaxAge);
+            y += 30;
 
             chkCsv  = new CheckBox { Left = 260, Top = y, Width = 80, Text = "CSV", Checked = _cfg.DefaultWriteCsv };
             chkXlsx = new CheckBox { Left = 340, Top = y, Width = 80, Text = "XLSX", Checked = _cfg.DefaultWriteXlsx }; y += 30;
@@ -55,10 +62,14 @@ namespace BirthdayExtractor
             y += 35;
 
             Controls.Add(new Label { Left = 20, Top = y, Width = 220, Text = "Webhook URL (future):" });
-            txtWebhookUrl = new TextBox { Left = 260, Top = y - 4, Width = 200, Text = _cfg.WebhookUrl ?? "" }; y += 30;
+            txtWebhookUrl = new TextBox { Left = 260, Top = y - 4, Width = 200, Text = _cfg.WebhookUrl ?? "" };
+            Controls.Add(txtWebhookUrl);
+            y += 30;
 
             Controls.Add(new Label { Left = 20, Top = y, Width = 220, Text = "Webhook Auth header (future):" });
-            txtWebhookAuth = new TextBox { Left = 260, Top = y - 4, Width = 200, Text = _cfg.WebhookAuthHeader ?? "" }; y += 40;
+            txtWebhookAuth = new TextBox { Left = 260, Top = y - 4, Width = 200, Text = _cfg.WebhookAuthHeader ?? "" };
+            Controls.Add(txtWebhookAuth);
+            y += 40;
 
             btnSave = new Button { Left = 260, Top = y, Width = 90, Text = "Save" };
             btnCancel = new Button { Left = 370, Top = y, Width = 90, Text = "Cancel" };


### PR DESCRIPTION
## Summary
- add the numeric and text controls back to the settings dialog so all fields render again
- default new configurations to XLSX-only output and enable libphonenumber parsing by default

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6903b66b0832593a1aeff7f14e66c