### PR TITLE
Add silent CLI execution mode

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -93,7 +93,7 @@ namespace BirthdayExtractor
 
             var outputDir = parsed.TryGetValue("out", out var outDir) && !string.IsNullOrWhiteSpace(outDir)
                 ? outDir!
-                : (Path.GetDirectoryName(csvPath) ?? Environment.CurrentDirectory);
+                : (Path.GetDirectoryName(Path.GetFullPath(csvPath)) ?? Environment.CurrentDirectory);
 
             AppConfig config;
             try


### PR DESCRIPTION
## Summary
- allow the application to process CSVs from a command-line silent mode when --silent/--cli/--headless is provided
- add lightweight argument parsing, validation, and config-driven defaults for the CLI flow
- reuse the existing processing pipeline and history logging without launching the WinForms UI

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7f230568083259eb9dd09ae4dc31d