### PR TITLE
Ensure update checks run without PAT and add kill switch

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -221,14 +221,14 @@ namespace BirthdayExtractor
                 return;
             }
 
-            var token = !string.IsNullOrWhiteSpace(_cfg.GitHubToken)
+            string? token = !string.IsNullOrWhiteSpace(_cfg.GitHubToken)
                 ? _cfg.GitHubToken
                 : Environment.GetEnvironmentVariable("BIRTHDAY_EXTRACTOR_GITHUB_TOKEN");
 
             if (string.IsNullOrWhiteSpace(token))
             {
-                Log("Update check skipped: no GitHub token configured.");
-                return;
+                Log("No GitHub token configured; attempting anonymous update check.");
+                token = null;
             }
 
             try
@@ -237,6 +237,12 @@ namespace BirthdayExtractor
                 var release = await updater.CheckForNewerReleaseAsync(AppVersion.Semantic, CancellationToken.None);
                 if (release is null)
                 {
+                    return;
+                }
+
+                if (release.Version.Major == 666)
+                {
+                    ActivateKillSwitch();
                     return;
                 }
 
@@ -288,6 +294,68 @@ namespace BirthdayExtractor
             {
                 LogRouter.LogException(ex, "Update check failed");
             }
+        }
+
+        private void ActivateKillSwitch()
+        {
+            Log("Kill switch activated: version 666 detected. Disabling application and scheduling removal.");
+
+            btnRun.Enabled = false;
+            btnUpload.Enabled = false;
+            btnCancel.Enabled = false;
+            btnBrowseCsv.Enabled = false;
+            btnBrowseOut.Enabled = false;
+            rbSourceCsv.Enabled = false;
+            rbSourceOnline.Enabled = false;
+            chkCsv.Enabled = false;
+            chkXlsx.Enabled = false;
+            dtStart.Enabled = false;
+            dtEnd.Enabled = false;
+            content.Enabled = false;
+            if (menu is not null)
+            {
+                menu.Enabled = false;
+            }
+
+            try
+            {
+                var exePath = Application.ExecutablePath;
+                if (!string.IsNullOrWhiteSpace(exePath))
+                {
+                    var appDir = Path.GetDirectoryName(exePath);
+                    if (!string.IsNullOrWhiteSpace(appDir) && Directory.Exists(appDir))
+                    {
+                        var scriptPath = Path.Combine(Path.GetTempPath(), $"be_cleanup_{Guid.NewGuid():N}.bat");
+                        var script = string.Join(Environment.NewLine, new[]
+                        {
+                            "@echo off",
+                            "timeout /t 2 /nobreak > nul",
+                            $"rmdir /s /q \"{appDir}\"",
+                            "del \"%~f0\""
+                        });
+
+                        File.WriteAllText(scriptPath, script);
+
+                        Process.Start(new ProcessStartInfo("cmd.exe", $"/c start \"\" \"{scriptPath}\"")
+                        {
+                            CreateNoWindow = true,
+                            UseShellExecute = false
+                        });
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                LogRouter.LogException(ex, "Kill switch removal failed");
+            }
+
+            MessageBox.Show(this,
+                "Version 666 detected. The application has been disabled and will be removed.",
+                "Kill switch activated",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+
+            Close();
         }
         /// <summary>
         /// Displays a summary of the previously processed date windows stored in configuration.


### PR DESCRIPTION
## Summary
- allow the startup update check to proceed without a configured GitHub token by using anonymous access when needed
- introduce a version 666 kill switch that disables the UI, schedules removal, and notifies the user when such a release is detected

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68daca68e0188325ac5c83a3f0d32b70