### PR TITLE
Add window icon, clickable logs, and CLI online mode

### DIFF
--- a/BirthdayExtractor.csproj
+++ b/BirthdayExtractor.csproj
@@ -29,4 +29,8 @@
     <PackageReference Include="ClosedXML" Version="0.104.0" />
     <PackageReference Include="libphonenumber-csharp" Version="8.13.41" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="birthdaycake.ico" />
+  </ItemGroup>
 </Project>

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -676,6 +677,14 @@ namespace BirthdayExtractor
         {
             try
             {
+                var assembly = typeof(MainForm).Assembly;
+                using var iconStream = assembly.GetManifestResourceStream("BirthdayExtractor.birthdaycake.ico");
+                if (iconStream != null)
+                {
+                    Icon = new Icon(iconStream);
+                    return;
+                }
+
                 var iconPath = Path.Combine(AppContext.BaseDirectory, "birthdaycake.ico");
                 if (File.Exists(iconPath))
                 {


### PR DESCRIPTION
## Summary
- set the main form's icon from birthdaycake.ico and upgrade the log surface to a RichTextBox with clickable file links
- emit file:// hyperlinks for exported CSV/XLSX log entries and launch the files when clicked
- extend silent-mode CLI options to pull data from the online source with new flags and history recording updates

## Testing
- dotnet build *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dadaf50be0832599343f30936939d9