### PR TITLE
Add ERPNext dry run CLI option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ Birthday_Extractor.code-workspace
 # Ignore all files in a directory but re-include a specific one
 /temp/*
 !/temp/important.txt
+
+*.exe
+*.xlsx
+*.csv
+*.txt

--- a/ErpNextClient.cs
+++ b/ErpNextClient.cs
@@ -210,7 +210,7 @@ namespace BirthdayExtractor
                 ["doctype"] = "Lead",
                 ["naming_series"] = "CRM-LEAD-.YYYY.-",
                 ["source"] = "Outbound", 
-                ["status"] = "Outbound", 
+                ["status"] = "Initial Contact", 
                 ["first_name"] = parentFirst,
                 ["last_name"] = parentLast,
                 ["mobile_no"] = phone,

--- a/ErpNextClient.cs
+++ b/ErpNextClient.cs
@@ -188,7 +188,7 @@ namespace BirthdayExtractor
         /// <summary>
         /// Constructs the JSON payload for creating a new ERPNext Lead from an ExtractedLead object.
         /// </summary>
-        private static Dictionary<string, object?> BuildLeadPayload(ExtractedLead lead, DateTime now)
+        internal static Dictionary<string, object?> BuildLeadPayload(ExtractedLead lead, DateTime now)
         {
             var (parentFirst, parentLast) = ResolveGuardianNames(lead);
             var childName = string.Join(" ", new[] { lead.ChildFirstName, lead.ChildLastName }

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -94,18 +97,46 @@ namespace BirthdayExtractor
                 }
             }
 
-            if (!parsed.TryGetValue("start", out var startText) || !TryParseDate(startText, out var start))
+            AppConfig config;
+            try
             {
-                Console.Error.WriteLine("ERROR: --start <yyyy-MM-dd> is required when running in silent mode.");
-                Environment.ExitCode = 1;
-                return true;
+                config = ConfigStore.LoadOrCreate() ?? new AppConfig();
+            }
+            catch (Exception ex)
+            {
+                config = new AppConfig();
+                LogRouter.LogException(ex, "Failed to load configuration");
             }
 
-            if (!parsed.TryGetValue("end", out var endText) || !TryParseDate(endText, out var end))
+            DateTime start;
+            if (parsed.TryGetValue("start", out var startText) && !string.IsNullOrWhiteSpace(startText))
             {
-                Console.Error.WriteLine("ERROR: --end <yyyy-MM-dd> is required when running in silent mode.");
-                Environment.ExitCode = 1;
-                return true;
+                if (!TryParseDate(startText, out start))
+                {
+                    Console.Error.WriteLine("ERROR: --start must be formatted as yyyy-MM-dd.");
+                    Environment.ExitCode = 1;
+                    return true;
+                }
+            }
+            else
+            {
+                start = DateTime.Today.AddDays(config.DefaultStartOffsetDays);
+            }
+
+            DateTime end;
+            if (parsed.TryGetValue("end", out var endText) && !string.IsNullOrWhiteSpace(endText))
+            {
+                if (!TryParseDate(endText, out end))
+                {
+                    Console.Error.WriteLine("ERROR: --end must be formatted as yyyy-MM-dd.");
+                    Environment.ExitCode = 1;
+                    return true;
+                }
+            }
+            else
+            {
+                var windowDays = Math.Max(1, config.DefaultWindowDays);
+                end = start.AddDays(windowDays - 1);
             }
 
             if (end < start)
@@ -120,17 +151,6 @@ namespace BirthdayExtractor
                 : (!useOnlineSource && !string.IsNullOrWhiteSpace(csvPath)
                     ? Path.GetDirectoryName(Path.GetFullPath(csvPath)) ?? Environment.CurrentDirectory
                     : Environment.CurrentDirectory);
-
-            AppConfig config;
-            try
-            {
-                config = ConfigStore.LoadOrCreate() ?? new AppConfig();
-            }
-            catch (Exception ex)
-            {
-                config = new AppConfig();
-                LogRouter.LogException(ex, "Failed to load configuration");
-            }
 
             string? remoteEndpoint = null;
             string? remoteCookie = null;
@@ -169,9 +189,16 @@ namespace BirthdayExtractor
             var writeCsv = GetFlag(parsed, "csv-out", config.DefaultWriteCsv) && !GetFlag(parsed, "no-csv-out");
             var writeXlsx = GetFlag(parsed, "xlsx-out", config.DefaultWriteXlsx) && !GetFlag(parsed, "no-xlsx-out");
             var uploadErpNext = GetFlag(parsed, "erpnext") || GetFlag(parsed, "erp-upload");
+            var dryRun = GetFlag(parsed, "dryrun") || GetFlag(parsed, "dry-run");
             if (GetFlag(parsed, "no-erpnext"))
             {
                 uploadErpNext = false;
+            }
+            if (dryRun && !uploadErpNext)
+            {
+                Console.Error.WriteLine("ERROR: --dryrun requires --erpnext.");
+                Environment.ExitCode = 1;
+                return true;
             }
             var quiet = GetFlag(parsed, "quiet");
 
@@ -242,36 +269,70 @@ namespace BirthdayExtractor
                         return true;
                     }
 
-                    if (string.IsNullOrWhiteSpace(erpBaseUrl) || string.IsNullOrWhiteSpace(erpApiKey) || string.IsNullOrWhiteSpace(erpApiSecret))
+                    if (dryRun)
                     {
-                        Console.Error.WriteLine("ERROR: ERPNext credentials are required. Use --erp-base, --erp-key, and --erp-secret or configure them in the app.");
-                        Environment.ExitCode = 1;
-                        return true;
-                    }
-
-                    if (!quiet)
-                    {
-                        Console.WriteLine("Starting ERPNext upload...");
-                    }
-
-                    try
-                    {
-                        var summary = RunErpNextUpload(result.Leads, new ErpNextUploadOptions(erpBaseUrl!, erpApiKey!, erpApiSecret!)
+                        try
                         {
-                            UploadTimestamp = DateTime.Now
-                        }, quiet ? null : (Action<string>)(m => Console.WriteLine($"{DateTime.Now:HH:mm:ss}  {m}")));
-
-                        if (summary.Failed > 0)
+                            var timestamp = DateTime.Now;
+                            var dryRunPath = WriteErpNextDryRunFile(result.Leads, timestamp, out var written, out var missingKeys, out var missingRequired);
+                            if (quiet)
+                            {
+                                Console.WriteLine(dryRunPath);
+                            }
+                            else
+                            {
+                                Console.WriteLine($"ERPNext dry run wrote {written} lead payload(s) to {dryRunPath}.");
+                                if (missingKeys > 0)
+                                {
+                                    Console.WriteLine($"Skipped {missingKeys} lead(s) missing a business key.");
+                                }
+                                if (missingRequired > 0)
+                                {
+                                    Console.WriteLine($"Skipped {missingRequired} lead(s) missing required fields.");
+                                }
+                            }
+                        }
+                        catch (Exception dryRunEx)
                         {
-                            exitCode = Math.Max(exitCode, 2);
+                            Console.Error.WriteLine("ERROR writing ERPNext dry run file: " + dryRunEx.Message);
+                            LogRouter.LogException(dryRunEx, "ERROR writing ERPNext dry run file");
+                            Environment.ExitCode = 1;
+                            return true;
                         }
                     }
-                    catch (Exception uploadEx)
+                    else
                     {
-                        Console.Error.WriteLine("ERROR during ERPNext upload: " + uploadEx.Message);
-                        LogRouter.LogException(uploadEx, "ERROR during ERPNext upload");
-                        Environment.ExitCode = 1;
-                        return true;
+                        if (string.IsNullOrWhiteSpace(erpBaseUrl) || string.IsNullOrWhiteSpace(erpApiKey) || string.IsNullOrWhiteSpace(erpApiSecret))
+                        {
+                            Console.Error.WriteLine("ERROR: ERPNext credentials are required. Use --erp-base, --erp-key, and --erp-secret or configure them in the app.");
+                            Environment.ExitCode = 1;
+                            return true;
+                        }
+
+                        if (!quiet)
+                        {
+                            Console.WriteLine("Starting ERPNext upload...");
+                        }
+
+                        try
+                        {
+                            var summary = RunErpNextUpload(result.Leads, new ErpNextUploadOptions(erpBaseUrl!, erpApiKey!, erpApiSecret!)
+                            {
+                                UploadTimestamp = DateTime.Now
+                            }, quiet ? null : (Action<string>)(m => Console.WriteLine($"{DateTime.Now:HH:mm:ss}  {m}")));
+
+                            if (summary.Failed > 0)
+                            {
+                                exitCode = Math.Max(exitCode, 2);
+                            }
+                        }
+                        catch (Exception uploadEx)
+                        {
+                            Console.Error.WriteLine("ERROR during ERPNext upload: " + uploadEx.Message);
+                            LogRouter.LogException(uploadEx, "ERROR during ERPNext upload");
+                            Environment.ExitCode = 1;
+                            return true;
+                        }
                     }
                 }
 
@@ -369,6 +430,72 @@ namespace BirthdayExtractor
             return ErpNextUploader.UploadAsync(leads, options, logger, CancellationToken.None).GetAwaiter().GetResult();
         }
 
+        private static string WriteErpNextDryRunFile(IReadOnlyList<ExtractedLead> leads, DateTime timestamp, out int included, out int missingBusinessKey, out int missingRequired)
+        {
+            if (leads is null) throw new ArgumentNullException(nameof(leads));
+
+            missingBusinessKey = 0;
+            missingRequired = 0;
+            var payloads = new List<Dictionary<string, object?>>();
+
+            foreach (var lead in leads.Where(l => l is not null))
+            {
+                if (string.IsNullOrWhiteSpace(lead!.BusinessKey))
+                {
+                    missingBusinessKey++;
+                    continue;
+                }
+
+                var missingFields = ErpNextClient.GetMissingRequiredFields(lead);
+                if (missingFields.Count > 0)
+                {
+                    missingRequired++;
+                    continue;
+                }
+
+                payloads.Add(ErpNextClient.BuildLeadPayload(lead, timestamp));
+            }
+
+            included = payloads.Count;
+
+            var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (string.IsNullOrWhiteSpace(documentsPath) || !Directory.Exists(documentsPath))
+            {
+                documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            }
+            if (string.IsNullOrWhiteSpace(documentsPath) || !Directory.Exists(documentsPath))
+            {
+                documentsPath = Environment.CurrentDirectory;
+            }
+
+            var targetDirectory = Path.Combine(documentsPath, "BirthdayExtractor");
+            Directory.CreateDirectory(targetDirectory);
+
+            var fileName = $"erpnext-dryrun-{timestamp:yyyyMMdd-HHmmss}.json";
+            var fullPath = Path.Combine(targetDirectory, fileName);
+
+            var manifest = new
+            {
+                GeneratedAt = timestamp,
+                TotalLeads = leads.Count,
+                Included = payloads,
+                SkippedMissingBusinessKey = missingBusinessKey,
+                SkippedMissingRequiredFields = missingRequired
+            };
+
+            var jsonOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            var json = JsonSerializer.Serialize(manifest, jsonOptions);
+            File.WriteAllText(fullPath, json);
+
+            return fullPath;
+        }
+
         private static bool TryParseDate(string? text, out DateTime value)
         {
             if (string.IsNullOrWhiteSpace(text))
@@ -455,6 +582,7 @@ namespace BirthdayExtractor
             Console.WriteLine("  --quiet                 Suppress console logging");
             Console.WriteLine("  --erpnext               Upload results directly to ERPNext");
             Console.WriteLine("  --no-erpnext            Skip ERPNext upload (overrides --erpnext)");
+            Console.WriteLine("  --dryrun                With --erpnext, write ERP payload JSON to Documents instead of uploading");
             Console.WriteLine("  --erp-base <url>        Override ERPNext base URL");
             Console.WriteLine("  --erp-key <value>       Override ERPNext API key");
             Console.WriteLine("  --erp-secret <value>    Override ERPNext API secret");

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+This document provides a high-level overview of the Birthday Extractor project to give context to AI agents and new developers.
+
+## Project Summary
+
+**Birthday Extractor** is a C# Windows Forms (.NET) application designed to process customer data to identify children with upcoming birthdays. It serves as a tool for marketing and customer relationship management (CRM) by generating targeted lead lists.
+
+The core functionality includes:
+1.  **Data Ingestion**: It can read customer data from two sources:
+    *   A local CSV file.
+    *   A remote online API endpoint.
+2.  **Filtering**: It filters the customer list to find children whose birthdays fall within a user-specified date range and whose age on their birthday falls within a configured minimum and maximum age (e.g., 3-14 years old).
+3.  **Data Processing**: It performs data normalization, particularly for phone numbers (using `libphonenumber-csharp`), and attempts to link child records to their parent/guardian records from the same dataset based on shared email or phone numbers.
+4.  **Output Generation**: The filtered list of birthday leads can be exported as:
+    *   A CSV file.
+    *   An XLSX (Excel) file with table formatting.
+5.  **ERP Integration**: It has an optional feature to upload the generated leads directly into an ERPNext instance as "Lead" documents, checking for duplicates to avoid re-inserting existing leads.
+6.  **Silent/CLI Mode**: The application can be run from the command line for automated, headless operation.
+7.  **Auto-Update**: It includes a mechanism to check for new versions on GitHub and perform an in-place update.
+
+## Key Components & Architecture
+
+The project is structured into several key classes, each with a distinct responsibility.
+
+### Application Entry & UI
+
+*   `Program.cs`: The main entry point. It handles parsing command-line arguments for silent mode and initializes the Windows Forms application if no CLI arguments are provided.
+*   `MainForm.cs`: The primary UI window. It's built programmatically (without a `.designer.cs` file). It allows the user to configure and trigger the extraction process, view logs, access settings, and see processing history. It orchestrates calls to the processing and upload logic.
+
+### Core Logic
+
+*   `Processing.cs`: This is the heart of the application. The `Processing` class contains the entire data processing pipeline. It is stateless and takes a `ProcOptions` object as input. Its `Process` method performs the following steps:
+    1.  Reads data from the specified source (CSV or online).
+    2.  Normalizes raw data into an internal `Row` representation.
+    3.  Parses dates of birth and normalizes phone numbers.
+    4.  Identifies adults (potential guardians) and children.
+    5.  Filters for children with birthdays in the target window and age range.
+    6.  Correlates children with their guardians.
+    7.  Generates a unique `BusinessKey` for each lead to assist with deduplication.
+    8.  Writes the final, sorted list to CSV and/or XLSX files.
+    9.  Returns a `ProcResult` object containing the outcome and the list of `ExtractedLead` objects.
+
+### Configuration & State
+
+*   `AppConfig.cs`: Defines the `AppConfig` data model, which stores all user preferences, API credentials, and run history.
+*   `ConfigStore.cs`: A static helper class responsible for serializing `AppConfig` to and from a `config.json` file located in the user's `%LOCALAPPDATA%\BirthdayExtractor` directory. It also includes a utility for computing file hashes.
+
+### Integrations
+
+*   `ErpNextClient.cs`: A low-level client for interacting with the ERPNext REST API. It handles authentication and the specifics of fetching existing leads (to check for duplicates) and creating new ones.
+*   `ErpNextUploader.cs`: A high-level orchestrator that uses `ErpNextClient` to manage the batch upload process. It filters out leads with missing required data, checks for existing leads using the `BusinessKey`, and reports a summary of the operation.
+*   `UpdateService.cs` (referenced, not provided): A class responsible for querying the GitHub API to check for new application releases.
+*   `SelfUpdateCoordinator.cs`: Manages the tricky process of the application replacing its own executable file after an update is downloaded.
+
+### Utilities
+
+*   `LogRouter.cs`: A static class providing a centralized logging sink. It can queue log messages and forward them to the `MainForm`'s log view once it's available, allowing non-UI components to provide user-visible feedback.
+*   `AppVersion.cs`: A simple static class that centralizes the application's version string (`Display`) and its parsed `System.Version` equivalent (`Semantic`).
+
+## Key Data Models
+
+*   `ProcOptions`: An object that encapsulates all parameters for a single processing run (e.g., dates, paths, ages, output flags).
+*   `ProcResult`: An object that summarizes the results of a processing run, including counts and paths to output files.
+*   `ExtractedLead`: A clean, flattened data transfer object (DTO) representing a single child/guardian lead, used for the ERPNext upload.
+*   `ProcessedWindow`: A record stored in `AppConfig.History` that logs a completed run (date range, source file info, and result count) to help users avoid duplicate work.
+
+## Primary Workflows
+
+1.  **GUI Workflow**: The user interacts with `MainForm` to select a CSV or use the configured online source, sets the date and age parameters, and clicks "Run". `MainForm` calls `Processing.Process`. If the run is successful and produces leads, the "Upload to ERPNext" button is enabled.
+
+2.  **CLI Workflow**: The user runs the executable with command-line flags like `--silent`, `--csv <path>`, `--start <date>`, and `--end <date>`. `Program.cs` parses these arguments, builds a `ProcOptions` object, and directly calls `Processing.Process`. It can also trigger an ERPNext upload if requested via flags.
+
+3.  **Update Workflow**: On startup, `MainForm` checks for updates via the `UpdateService`. If a new version is found and the user agrees, it's downloaded. A batch script is created to replace the old executable with the new one and relaunch the application. `SelfUpdateCoordinator` handles the logic for the newly launched executable to put itself in the correct installation directory.

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,1 @@
+& "D:\Documents\Code Projects\Birthday_Extractor\Birthday_Extractor.exe" "--silent" "--online" "--erpnext"  | Out-File -FilePath "D:\Documents\Code Projects\Birthday_Extractor\OutputFile.txt" -Encoding UTF8


### PR DESCRIPTION
## Summary
- add a --dryrun CLI flag that requires --erpnext and validates its usage
- write the ERPNext upload payloads to a JSON file in the user's Documents folder when dry running
- expose the ERPNext payload builder so the CLI can reuse it and update help text accordingly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ff2f46e25c8325b83c3bf2b7496995